### PR TITLE
Email formatting

### DIFF
--- a/resources/views/mail/payment/confirmed.blade.php
+++ b/resources/views/mail/payment/confirmed.blade.php
@@ -1,16 +1,16 @@
 @component('mail::message')
 # Thank you for your purchase!
-Your payment has been confirmed; Your credit balance has been updated.
+Your payment has been confirmed; Your credit balance has been updated.<br>
 
 # Details
 ___
-### Payment ID: **{{$payment->id}}**
-### Status:     **{{$payment->status}}**
-### Price:      **{{$payment->formatCurrency()}}**
-### Type:       **{{$payment->type}}**
-### Amount:     **{{$payment->amount}}**
-### Balance:    **{{$payment->user->credits}}**
-### User ID:    **{{$payment->user_id}}**
+### Payment ID: **{{$payment->id}}**<br>
+### Status:     **{{$payment->status}}**<br>
+### Price:      **{{$payment->formatCurrency()}}**<br>
+### Type:       **{{$payment->type}}**<br>
+### Amount:     **{{$payment->amount}}**<br>
+### Balance:    **{{$payment->user->credits}}**<br>
+### User ID:    **{{$payment->user_id}}**<br>
 
 <br>
 Thanks,<br>


### PR DESCRIPTION
Added spaces to confirmed payment email, as some mail clients cannot format it well
![image](https://user-images.githubusercontent.com/85408287/124109040-08db2b80-da67-11eb-80f9-78e9d8b062cb.png)
