### PR TITLE
fixed a bug: is ptero is down don't delete the server from our side

### DIFF
--- a/app/Http/Controllers/Admin/ServerController.php
+++ b/app/Http/Controllers/Admin/ServerController.php
@@ -90,8 +90,12 @@ class ServerController extends Controller
      */
     public function destroy(Server $server)
     {
-        $server->delete();
-        return redirect()->back()->with('success', 'server has been removed!');
+        try {
+            $server->delete();
+            return redirect()->route('admin.servers.index')->with('success', 'server removed');
+        } catch (Exception $e) {
+            return redirect()->route('admin.servers.index')->with('error', 'An exception has occurred while trying to remove a resource "' . $e->getMessage() . '"');
+        }
     }
 
     /**

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -111,7 +111,7 @@ class ServerController extends Controller
             $server->delete();
             return redirect()->route('servers.index')->with('success', 'server removed');
         } catch (Exception $e) {
-            return redirect()->route('servers.index')->with('error', 'An exception has occurred while trying to remove a resource');
+            return redirect()->route('servers.index')->with('error', 'An exception has occurred while trying to remove a resource "' . $e->getMessage() . '"');
         }
     }
 

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -70,7 +70,8 @@ class Server extends Model
         });
 
         static::deleting(function (Server $server) {
-            Pterodactyl::client()->delete("/application/servers/{$server->pterodactyl_id}");
+            $response = Pterodactyl::client()->delete("/application/servers/{$server->pterodactyl_id}");
+            if ($response->failed()) throw new Exception($response['errors'][0]['code']);
         });
     }
 


### PR DESCRIPTION
if pterodactylpanel would be down and you would delete your server then it would be removed from controlpanel but not from pterodactyl, it now makes sure to delete on pterodactyl before deleting on controlpanel