### PR TITLE
Fix division by zero

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -67,6 +67,7 @@
                 </div>
                 <!-- /.col -->
 
+                @if($useage > 0)
                 <div class="col-12 col-sm-6 col-md-3">
                     <div class="info-box mb-3">
                         @if(number_format((Auth::user()->Credits()*30)/$useage,0,'.','') >= 15)
@@ -91,6 +92,7 @@
                     <!-- /.info-box -->
                 </div>
                 <!-- /.col -->
+                @endif
 
             </div>
 


### PR DESCRIPTION
The page shows error 500 if usage is 0, this pull request removes the Out of Credits info box if the usage is 0.