### PR TITLE
fix: 🚑️ swapped nodes/eggs column naming -> now correct order

### DIFF
--- a/resources/views/admin/products/index.blade.php
+++ b/resources/views/admin/products/index.blade.php
@@ -11,8 +11,7 @@
                 <div class="col-sm-6">
                     <ol class="breadcrumb float-sm-right">
                         <li class="breadcrumb-item"><a href="{{ route('home') }}">Dashboard</a></li>
-                        <li class="breadcrumb-item"><a class="text-muted"
-                                href="{{ route('admin.products.index') }}">Products</a></li>
+                        <li class="breadcrumb-item"><a class="text-muted" href="{{ route('admin.products.index') }}">Products</a></li>
                     </ol>
                 </div>
             </div>
@@ -29,8 +28,7 @@
                 <div class="card-header">
                     <div class="d-flex justify-content-between">
                         <h5 class="card-title"><i class="fas fa-sliders-h mr-2"></i>Products</h5>
-                        <a href="{{ route('admin.products.create') }}" class="btn btn-sm btn-primary"><i
-                                class="fas fa-plus mr-1"></i>Create new</a>
+                        <a href="{{ route('admin.products.create') }}" class="btn btn-sm btn-primary"><i class="fas fa-plus mr-1"></i>Create new</a>
                     </div>
                 </div>
 
@@ -38,25 +36,24 @@
 
                     <table id="datatable" class="table table-striped">
                         <thead>
-                            <tr>
-                                <th>Active</th>
-                                <th>Name</th>
-                                <th>Price</th>
-                                <th>Memory</th>
-                                <th>Cpu</th>
-                                <th>Swap</th>
-                                <th>Disk</th>
-                                <th>Databases</th>
-                                <th>Backups</th>
-                                <th>Nodes</th>
-                                <th>Eggs</th>
-                                <th>Servers</th>
-                                <th>Created at</th>
-                                <th></th>
-                            </tr>
+                        <tr>
+                            <th>Active</th>
+                            <th>Name</th>
+                            <th>Price</th>
+                            <th>Memory</th>
+                            <th>Cpu</th>
+                            <th>Swap</th>
+                            <th>Disk</th>
+                            <th>Databases</th>
+                            <th>Backups</th>
+                            <th>Nodes</th>
+                            <th>Eggs</th>
+                            <th>Servers</th>
+                            <th>Created at</th>
+                            <th></th>
+                        </tr>
                         </thead>
-                        <tbody>
-                        </tbody>
+                        <tbody></tbody>
                     </table>
 
                 </div>
@@ -74,64 +71,33 @@
             return confirm("Are you sure you wish to delete?") !== false;
         }
 
-        document.addEventListener("DOMContentLoaded", function() {
-            $('#datatable').DataTable({
+        document.addEventListener("DOMContentLoaded", function () {
+            $("#datatable").DataTable({
                 processing: true,
                 serverSide: true,
                 stateSave: true,
                 order: [
-                    [2, "asc"]
+                    [ 2, "asc" ]
                 ],
                 ajax: "{{ route('admin.products.datatable') }}",
-                columns: [{
-                        data: 'disabled'
-                    },
-                    {
-                        data: 'name'
-                    },
-                    {
-                        data: 'price'
-                    },
-                    {
-                        data: 'memory'
-                    },
-                    {
-                        data: 'cpu'
-                    },
-                    {
-                        data: 'swap'
-                    },
-                    {
-                        data: 'disk'
-                    },
-                    {
-                        data: 'databases'
-                    },
-                    {
-                        data: 'backups'
-                    },
-                    {
-                        data: 'nodes',
-                        sortable: false
-                    },
-                    {
-                        data: 'eggs',
-                        sortable: false
-                    },
-                    {
-                        data: 'servers',
-                        sortable: false
-                    },
-                    {
-                        data: 'created_at'
-                    },
-                    {
-                        data: 'actions',
-                        sortable: false
-                    },
+                columns: [
+                    {data: "disabled"},
+                    {data: "name"},
+                    {data: "price"},
+                    {data: "memory"},
+                    {data: "cpu"},
+                    {data: "swap"},
+                    {data: "disk"},
+                    {data: "databases"},
+                    {data: "backups"},
+                    {data: "nodes", sortable: false},
+                    {data: "eggs", sortable: false},
+                    {data: "servers", sortable: false},
+                    {data: "created_at"},
+                    {data: "actions", sortable: false}
                 ],
-                fnDrawCallback: function(oSettings) {
-                    $('[data-toggle="popover"]').popover();
+                fnDrawCallback: function (oSettings) {
+                    $("[data-toggle=\"popover\"]").popover();
                 }
             });
         });

--- a/resources/views/admin/products/index.blade.php
+++ b/resources/views/admin/products/index.blade.php
@@ -10,9 +10,9 @@
                 </div>
                 <div class="col-sm-6">
                     <ol class="breadcrumb float-sm-right">
-                        <li class="breadcrumb-item"><a href="{{route('home')}}">Dashboard</a></li>
+                        <li class="breadcrumb-item"><a href="{{ route('home') }}">Dashboard</a></li>
                         <li class="breadcrumb-item"><a class="text-muted"
-                                                       href="{{route('admin.products.index')}}">Products</a></li>
+                                href="{{ route('admin.products.index') }}">Products</a></li>
                     </ol>
                 </div>
             </div>
@@ -29,7 +29,7 @@
                 <div class="card-header">
                     <div class="d-flex justify-content-between">
                         <h5 class="card-title"><i class="fas fa-sliders-h mr-2"></i>Products</h5>
-                        <a href="{{route('admin.products.create')}}" class="btn btn-sm btn-primary"><i
+                        <a href="{{ route('admin.products.create') }}" class="btn btn-sm btn-primary"><i
                                 class="fas fa-plus mr-1"></i>Create new</a>
                     </div>
                 </div>
@@ -38,22 +38,22 @@
 
                     <table id="datatable" class="table table-striped">
                         <thead>
-                        <tr>
-                            <th>Active</th>
-                            <th>Name</th>
-                            <th>Price</th>
-                            <th>Memory</th>
-                            <th>Cpu</th>
-                            <th>Swap</th>
-                            <th>Disk</th>
-                            <th>Databases</th>
-                            <th>Backups</th>
-                            <th>Eggs</th>
-                            <th>Nodes</th>
-                            <th>Servers</th>
-                            <th>Created at</th>
-                            <th></th>
-                        </tr>
+                            <tr>
+                                <th>Active</th>
+                                <th>Name</th>
+                                <th>Price</th>
+                                <th>Memory</th>
+                                <th>Cpu</th>
+                                <th>Swap</th>
+                                <th>Disk</th>
+                                <th>Databases</th>
+                                <th>Backups</th>
+                                <th>Nodes</th>
+                                <th>Eggs</th>
+                                <th>Servers</th>
+                                <th>Created at</th>
+                                <th></th>
+                            </tr>
                         </thead>
                         <tbody>
                         </tbody>
@@ -74,30 +74,63 @@
             return confirm("Are you sure you wish to delete?") !== false;
         }
 
-        document.addEventListener("DOMContentLoaded", function () {
+        document.addEventListener("DOMContentLoaded", function() {
             $('#datatable').DataTable({
                 processing: true,
                 serverSide: true,
                 stateSave: true,
-                order: [[ 2, "asc" ]],
-                ajax: "{{route('admin.products.datatable')}}",
-                columns: [
-                    {data: 'disabled'},
-                    {data: 'name'},
-                    {data: 'price'},
-                    {data: 'memory'},
-                    {data: 'cpu'},
-                    {data: 'swap'},
-                    {data: 'disk'},
-                    {data: 'databases'},
-                    {data: 'backups'},
-                    {data: 'nodes', sortable: false},
-                    {data: 'eggs', sortable: false},
-                    {data: 'servers', sortable: false},
-                    {data: 'created_at'},
-                    {data: 'actions', sortable: false},
+                order: [
+                    [2, "asc"]
                 ],
-                fnDrawCallback: function( oSettings ) {
+                ajax: "{{ route('admin.products.datatable') }}",
+                columns: [{
+                        data: 'disabled'
+                    },
+                    {
+                        data: 'name'
+                    },
+                    {
+                        data: 'price'
+                    },
+                    {
+                        data: 'memory'
+                    },
+                    {
+                        data: 'cpu'
+                    },
+                    {
+                        data: 'swap'
+                    },
+                    {
+                        data: 'disk'
+                    },
+                    {
+                        data: 'databases'
+                    },
+                    {
+                        data: 'backups'
+                    },
+                    {
+                        data: 'nodes',
+                        sortable: false
+                    },
+                    {
+                        data: 'eggs',
+                        sortable: false
+                    },
+                    {
+                        data: 'servers',
+                        sortable: false
+                    },
+                    {
+                        data: 'created_at'
+                    },
+                    {
+                        data: 'actions',
+                        sortable: false
+                    },
+                ],
+                fnDrawCallback: function(oSettings) {
                     $('[data-toggle="popover"]').popover();
                 }
             });


### PR DESCRIPTION
Fixed the column naming (nodes & eggs) in the products data table

![image](https://user-images.githubusercontent.com/54889359/143832303-dab026ff-4807-454d-8c07-3992cd67f936.png)
