### PR TITLE
HOTFIX: Error when calculating price+tax has 3 decimals

### DIFF
--- a/app/Models/PaypalProduct.php
+++ b/app/Models/PaypalProduct.php
@@ -43,7 +43,7 @@ class PaypalProduct extends Model
     /**
      * @param mixed $value
      * @param string $locale
-     * 
+     *
      * @return float
      */
     public function formatToCurrency($value,$locale = 'en_US')
@@ -70,7 +70,7 @@ class PaypalProduct extends Model
     */
     public function getTaxValue()
     {
-        return $this->price*$this->getTaxPercent()/100;
+        return number_format($this->price*$this->getTaxPercent()/100,2);
     }
 
     /**
@@ -78,8 +78,8 @@ class PaypalProduct extends Model
     *
     * @return float
     */
-    public function getTotalPrice() 
+    public function getTotalPrice()
     {
-        return $this->price+($this->getTaxValue());
+        return number_format($this->price+$this->getTaxValue(),2);
     }
 }


### PR DESCRIPTION
There was an error with the pricing and paypal

When the Product costs 2.50€  and you have 5% tax, that would calculate to 0.125€ making the total 2.625€

paypal can obivously not work with 3 decimals behind the price.

Rounding this up fixed the error.