### PR TITLE
Fixes line-breaks on Description when creation a server

### DIFF
--- a/resources/views/servers/create.blade.php
+++ b/resources/views/servers/create.blade.php
@@ -205,7 +205,7 @@
                                         </div>
                                         <div class="mt-2 mb-2">
                                             <span class="card-text text-muted">{{ __('Description') }}</span>
-                                            <p class="card-text" x-text="product.description"></p>
+                                            <p class="card-text" style="white-space:pre" x-text="product.description"></p>
                                         </div>
                                     </div>
                                     <div class="mt-auto border rounded border-secondary">


### PR DESCRIPTION
This fixes issue #392 and adds a simple style (AlpineJS styling) see [here](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#pre)

Please, if you know how to insert this as a CSS class. Tell me. Anyways have fun!