### PR TITLE
Fixes Ticket whitespace issue #507

### DIFF
--- a/resources/views/moderator/ticket/show.blade.php
+++ b/resources/views/moderator/ticket/show.blade.php
@@ -83,9 +83,7 @@
                                         <span class="badge badge-primary">{{ $ticket->created_at->diffForHumans() }}</span>
                                     </div>
                                 </div>
-                                <div class="card-body">
-                                    {{ $ticket->message }}
-                                </div>
+                                <div class="card-body" style="white-space:pre-wrap">{{ $ticket->message }}</div>
                             </div>
                             @foreach ($ticketcomments as $ticketcomment)
                             <div class="card">
@@ -108,9 +106,7 @@
                                         <span class="badge badge-primary">{{ $ticketcomment->created_at->diffForHumans() }}</span>
                                     </div>
                                 </div>
-                                <div class="card-body">
-                                    {{ $ticketcomment->ticketcomment }}
-                                </div>
+                                <div class="card-body" style="white-space:pre-wrap">{{ $ticketcomment->ticketcomment }}</div>
                             </div>
                             @endforeach
                             <div class="comment-form">

--- a/resources/views/ticket/show.blade.php
+++ b/resources/views/ticket/show.blade.php
@@ -83,9 +83,7 @@
                                         <span class="badge badge-primary">{{ $ticket->created_at->diffForHumans() }}</span>
                                     </div>
                                 </div>
-                                <div class="card-body">
-                                    {{ $ticket->message }}
-                                </div>
+                                <div class="card-body" tyle="white-space:pre-wrap">{{ $ticket->message }}</div>
                             </div>
                             @foreach ($ticketcomments as $ticketcomment)
                             <div class="card">
@@ -108,9 +106,7 @@
                                         <span class="badge badge-primary">{{ $ticketcomment->created_at->diffForHumans() }}</span>
                                     </div>
                                 </div>
-                                <div class="card-body">
-                                    {{ $ticketcomment->ticketcomment }}
-                                </div>
+                                <div class="card-body" style="white-space:pre-wrap">{{ $ticketcomment->ticketcomment }}</div>
                             </div>
                             @endforeach
                             <div class="comment-form">

--- a/resources/views/ticket/show.blade.php
+++ b/resources/views/ticket/show.blade.php
@@ -83,7 +83,7 @@
                                         <span class="badge badge-primary">{{ $ticket->created_at->diffForHumans() }}</span>
                                     </div>
                                 </div>
-                                <div class="card-body" tyle="white-space:pre-wrap">{{ $ticket->message }}</div>
+                                <div class="card-body" style="white-space:pre-wrap">{{ $ticket->message }}</div>
                             </div>
                             @foreach ($ticketcomments as $ticketcomment)
                             <div class="card">


### PR DESCRIPTION
#507 
This is not really in the format I wanted but it works... If I try 
div class="card-body" style="white-space:pre-wrap">
      { $ticket->message }}
/div
It messes up the format with blank space, Ive tried adding it to a <p> but the same thing occurs 