### PR TITLE
Delete server on 404 instead of giving error 500 to the user

### DIFF
--- a/app/Classes/Pterodactyl.php
+++ b/app/Classes/Pterodactyl.php
@@ -287,7 +287,7 @@ class Pterodactyl
      * @param int $pterodactylId
      * @return mixed
      */
-    public static function getServerAttributes(int $pterodactylId)
+    public static function getServerAttributes(int $pterodactylId, bool $deleteOn404 = false)
     {
         try {
             $response = self::client()->get("/application/servers/{$pterodactylId}?include=egg,node,nest,location");
@@ -299,7 +299,13 @@ class Pterodactyl
 
 
 
-        if ($response->failed()) throw self::getException("Failed to get server attributes from pterodactyl - ", $response->status());
+        if ($response->failed()){
+            if($deleteOn404){  //Delete the server if it does not exist (server deleted on pterodactyl)
+                Server::where('pterodactyl_id', $pterodactylId)->first()->delete();
+                return;
+            }
+            else throw self::getException("Failed to get server attributes from pterodactyl - ", $response->status());
+        }
         return $response->json()['attributes'];
     }
 

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -30,8 +30,8 @@ class ServerController extends Controller
         foreach ($servers as $server) {
 
             //Get server infos from ptero
-            $serverAttributes = Pterodactyl::getServerAttributes($server->pterodactyl_id);
-
+            $serverAttributes = Pterodactyl::getServerAttributes($server->pterodactyl_id, true);
+            if(!$serverAttributes) continue;
             $serverRelationships = $serverAttributes['relationships'];
             $serverLocationAttributes = $serverRelationships['location']['attributes'];
 


### PR DESCRIPTION
This commit prevents erroring out on a user if it got deleted on pterodactyl only. The deletion is only triggered upon loading the "/servers" route as I did not want to cause possible data loss due to some error.

I didn´t do anything about the ActivityLog, if the server gets deleted this way, a normal log message is being saved (User X deleted a server Y). Ideally, I would want It to say something like "Server X deleted by the system - server not found on pterodactyl".

Please, use with caution and review this code well.