### PR TITLE
Perpage limit fix - sync servers button

### DIFF
--- a/app/Http/Controllers/Admin/OverViewController.php
+++ b/app/Http/Controllers/Admin/OverViewController.php
@@ -102,16 +102,16 @@ class OverViewController extends Controller
             $nodeId = $server['attributes']['node'];
             
             if($CPServer = Server::query()->where('pterodactyl_id', $server['attributes']['id'])->first()){
-                $prize = Product::query()->where('id', $CPServer->product_id)->first()->price;
+                $price = Product::query()->where('id', $CPServer->product_id)->first()->price;
                 if (!$CPServer->suspended){
-                    $counters['earnings']->active += $prize;
+                    $counters['earnings']->active += $price;
                     $counters['servers']->active ++;
-                    $nodes[$nodeId]->activeEarnings += $prize;
+                    $nodes[$nodeId]->activeEarnings += $price;
                     $nodes[$nodeId]->activeServers ++;
                 }
-                $counters['earnings']->total += $prize;
+                $counters['earnings']->total += $price;
                 $counters['servers']->total ++;
-                $nodes[$nodeId]->totalEarnings += $prize;
+                $nodes[$nodeId]->totalEarnings += $price;
                 $nodes[$nodeId]->totalServers ++;
             }
         }

--- a/app/Http/Controllers/Admin/OverViewController.php
+++ b/app/Http/Controllers/Admin/OverViewController.php
@@ -22,103 +22,103 @@ class OverViewController extends Controller
 
     public function index()
     {
-        $counters = Cache::remember('counters', self::TTL, function () {
-            $output = collect();
-            //Set basic variables in the collection
-            $output->put('users', User::query()->count());
-            $output->put('credits', number_format(User::query()->where("role","!=","admin")->sum('credits'), 2, '.', ''));
-            $output->put('payments', Payment::query()->count());
-            $output->put('eggs', Egg::query()->count());
-            $output->put('nests', Nest::query()->count());
-            $output->put('locations', Location::query()->count());
+        //Get counters
+        $counters = collect();
+        //Set basic variables in the collection
+        $counters->put('users', User::query()->count());
+        $counters->put('credits', number_format(User::query()->where("role","!=","admin")->sum('credits'), 2, '.', ''));
+        $counters->put('payments', Payment::query()->count());
+        $counters->put('eggs', Egg::query()->count());
+        $counters->put('nests', Nest::query()->count());
+        $counters->put('locations', Location::query()->count());
 
-            //Prepare for counting
-            $output->put('servers', collect());
-            $output['servers']->active = 0;
-            $output['servers']->total = 0;
-            $output->put('earnings', collect());
-            $output['earnings']->active = 0;
-            $output['earnings']->total = 0;
-            $output->put('totalUsagePercent', 0);
+        //Prepare for counting
+        $counters->put('servers', collect());
+        $counters['servers']->active = 0;
+        $counters['servers']->total = 0;
+        $counters->put('earnings', collect());
+        $counters['earnings']->active = 0;
+        $counters['earnings']->total = 0;
+        $counters->put('totalUsagePercent', 0);
 
-            //Prepare subCollection 'payments'
-            $output->put('payments', collect());
-            //Get and save payments from last 2 months for later filtering and looping
-            $payments = Payment::query()->where('created_at', '>=', Carbon::today()->startOfMonth()->subMonth())->where('status', 'paid')->get();
-            //Prepare collections and set a few variables
-            $output['payments']->put('thisMonth', collect());
-            $output['payments']->put('lastMonth', collect());
-            $output['payments']['thisMonth']->timeStart = Carbon::today()->startOfMonth()->toDateString();
-            $output['payments']['thisMonth']->timeEnd = Carbon::today()->toDateString();
-            $output['payments']['lastMonth']->timeStart = Carbon::today()->startOfMonth()->subMonth()->toDateString();
-            $output['payments']['lastMonth']->timeEnd = Carbon::today()->endOfMonth()->subMonth()->toDateString();
-            
-            //Fill out variables for each currency separately
-            foreach($payments->where('created_at', '>=', Carbon::today()->startOfMonth()) as $payment){
-                $paymentCurrency = $payment->currency_code;
-                if(!isset($output['payments']['thisMonth'][$paymentCurrency])){
-                    $output['payments']['thisMonth']->put($paymentCurrency, collect());
-                    $output['payments']['thisMonth'][$paymentCurrency]->total = 0;
-                    $output['payments']['thisMonth'][$paymentCurrency]->count = 0;
-                }
-                $output['payments']['thisMonth'][$paymentCurrency]->total += $payment->total_price;
-                $output['payments']['thisMonth'][$paymentCurrency]->count ++;
+        //Prepare subCollection 'payments'
+        $counters->put('payments', collect());
+        //Get and save payments from last 2 months for later filtering and looping
+        $payments = Payment::query()->where('created_at', '>=', Carbon::today()->startOfMonth()->subMonth())->where('status', 'paid')->get();
+        //Prepare collections and set a few variables
+        $counters['payments']->put('thisMonth', collect());
+        $counters['payments']->put('lastMonth', collect());
+        $counters['payments']['thisMonth']->timeStart = Carbon::today()->startOfMonth()->toDateString();
+        $counters['payments']['thisMonth']->timeEnd = Carbon::today()->toDateString();
+        $counters['payments']['lastMonth']->timeStart = Carbon::today()->startOfMonth()->subMonth()->toDateString();
+        $counters['payments']['lastMonth']->timeEnd = Carbon::today()->endOfMonth()->subMonth()->toDateString();
+        
+        //Fill out variables for each currency separately
+        foreach($payments->where('created_at', '>=', Carbon::today()->startOfMonth()) as $payment){
+            $paymentCurrency = $payment->currency_code;
+            if(!isset($counters['payments']['thisMonth'][$paymentCurrency])){
+                $counters['payments']['thisMonth']->put($paymentCurrency, collect());
+                $counters['payments']['thisMonth'][$paymentCurrency]->total = 0;
+                $counters['payments']['thisMonth'][$paymentCurrency]->count = 0;
             }
-            foreach($payments->where('created_at', '<', Carbon::today()->startOfMonth()) as $payment){
-                $paymentCurrency = $payment->currency_code;
-                if(!isset($output['payments']['lastMonth'][$paymentCurrency])){
-                    $output['payments']['lastMonth']->put($paymentCurrency, collect());
-                    $output['payments']['lastMonth'][$paymentCurrency]->total = 0;
-                    $output['payments']['lastMonth'][$paymentCurrency]->count = 0;
-                }
-                $output['payments']['lastMonth'][$paymentCurrency]->total += $payment->total_price;
-                $output['payments']['lastMonth'][$paymentCurrency]->count ++;
+            $counters['payments']['thisMonth'][$paymentCurrency]->total += $payment->total_price;
+            $counters['payments']['thisMonth'][$paymentCurrency]->count ++;
+        }
+        foreach($payments->where('created_at', '<', Carbon::today()->startOfMonth()) as $payment){
+            $paymentCurrency = $payment->currency_code;
+            if(!isset($counters['payments']['lastMonth'][$paymentCurrency])){
+                $counters['payments']['lastMonth']->put($paymentCurrency, collect());
+                $counters['payments']['lastMonth'][$paymentCurrency]->total = 0;
+                $counters['payments']['lastMonth'][$paymentCurrency]->count = 0;
             }
-            $output['payments']->total = Payment::query()->count();
-            
-            return $output;
-        });
+            $counters['payments']['lastMonth'][$paymentCurrency]->total += $payment->total_price;
+            $counters['payments']['lastMonth'][$paymentCurrency]->count ++;
+        }
+        $counters['payments']->total = Payment::query()->count();
 
         $lastEgg = Egg::query()->latest('updated_at')->first();
         $syncLastUpdate = $lastEgg ? $lastEgg->updated_at->isoFormat('LLL') : __('unknown');
         
-        $nodes = Cache::remember('nodes', self::TTL, function() use($counters){
-            $output = collect();
-            foreach($nodes = Node::query()->get() as $node){ //gets all node information and prepares the structure
-                $nodeId = $node['id'];
-                $output->put($nodeId, collect());
-                $output[$nodeId]->name = $node['name'];
-                $node = Pterodactyl::getNode($nodeId);
-                $output[$nodeId]->usagePercent = round(max($node['allocated_resources']['memory']/($node['memory']*($node['memory_overallocate']+100)/100), $node['allocated_resources']['disk']/($node['disk']*($node['disk_overallocate']+100)/100))*100, 2);
-                $counters['totalUsagePercent'] += $output[$nodeId]->usagePercent;
 
-                $output[$nodeId]->totalServers = 0;
-                $output[$nodeId]->activeServers = 0;
-                $output[$nodeId]->totalEarnings = 0;
-                $output[$nodeId]->activeEarnings = 0;
-            }
-            $counters['totalUsagePercent'] = ($nodes->count())?round($counters['totalUsagePercent']/$nodes->count(), 2):0;
 
-            foreach(Pterodactyl::getServers() as $server){ //gets all servers from Pterodactyl and calculates total of credit usage for each node separately + total
-                $nodeId = $server['attributes']['node'];
-                
-                if($CPServer = Server::query()->where('pterodactyl_id', $server['attributes']['id'])->first()){
-                    $prize = Product::query()->where('id', $CPServer->product_id)->first()->price;
-                    if (!$CPServer->suspended){
-                        $counters['earnings']->active += $prize;
-                        $counters['servers']->active ++;
-                        $output[$nodeId]->activeEarnings += $prize;
-                        $output[$nodeId]->activeServers ++;
-                    }
-                    $counters['earnings']->total += $prize;
-                    $counters['servers']->total ++;
-                    $output[$nodeId]->totalEarnings += $prize;
-                    $output[$nodeId]->totalServers ++;
+        //Get node information
+        $nodes = collect();
+        foreach($DBnodes = Node::query()->get() as $DBnode){ //gets all node information and prepares the structure
+            $nodeId = $DBnode['id'];
+            $nodes->put($nodeId, collect());
+            $nodes[$nodeId]->name = $DBnode['name'];
+            $pteroNode = Pterodactyl::getNode($nodeId);
+            $nodes[$nodeId]->usagePercent = round(max($pteroNode['allocated_resources']['memory']/($pteroNode['memory']*($pteroNode['memory_overallocate']+100)/100), $pteroNode['allocated_resources']['disk']/($pteroNode['disk']*($pteroNode['disk_overallocate']+100)/100))*100, 2);
+            $counters['totalUsagePercent'] += $nodes[$nodeId]->usagePercent;
+
+            $nodes[$nodeId]->totalServers = 0;
+            $nodes[$nodeId]->activeServers = 0;
+            $nodes[$nodeId]->totalEarnings = 0;
+            $nodes[$nodeId]->activeEarnings = 0;
+        }
+        $counters['totalUsagePercent'] = ($DBnodes->count())?round($counters['totalUsagePercent']/$DBnodes->count(), 2):0;
+
+        foreach(Pterodactyl::getServers() as $server){ //gets all servers from Pterodactyl and calculates total of credit usage for each node separately + total
+            $nodeId = $server['attributes']['node'];
+            
+            if($CPServer = Server::query()->where('pterodactyl_id', $server['attributes']['id'])->first()){
+                $prize = Product::query()->where('id', $CPServer->product_id)->first()->price;
+                if (!$CPServer->suspended){
+                    $counters['earnings']->active += $prize;
+                    $counters['servers']->active ++;
+                    $nodes[$nodeId]->activeEarnings += $prize;
+                    $nodes[$nodeId]->activeServers ++;
                 }
+                $counters['earnings']->total += $prize;
+                $counters['servers']->total ++;
+                $nodes[$nodeId]->totalEarnings += $prize;
+                $nodes[$nodeId]->totalServers ++;
             }
-            return $output;
-        });
+        }
 
+
+
+        //Get latest tickets
         $tickets = Cache::remember('tickets', self::TTL, function(){
             $output = collect();
             foreach(Ticket::query()->latest()->take(3)->get() as $ticket){
@@ -146,7 +146,7 @@ class OverViewController extends Controller
             }
             return $output;
         });
-        //dd($counters);
+
         return view('admin.overview.index', [
             'counters'       => $counters,
             'nodes'          => $nodes,

--- a/resources/views/admin/overview/index.blade.php
+++ b/resources/views/admin/overview/index.blade.php
@@ -207,11 +207,13 @@
                             @if ($perPageLimit)
                                 <div class="alert alert-danger m-2">
                                     <h5><i class="icon fas fa-exclamation-circle"></i>{{ __('Error!') }}</h5>
-                                    <p class="">
+                                    <p class="mb-2">
                                         {{ __('You reached the Pterodactyl perPage limit. Please make sure to set it higher than your server count.') }}<br>
-                                        {{ __('You can do that in settings.') }}<br>
-                                        {{ __('Note') }}: {{ __('If this error persists even after changing the limit, it might mean a server was deleted on Pterodactyl, but not on ControlPanel.') }}
+                                        {{ __('You can do that in settings.') }}<br><br>
+                                        {{ __('Note') }}: {{ __('If this error persists even after changing the limit, it might mean a server was deleted on Pterodactyl, but not on ControlPanel. Try clicking the button below.') }}
                                     </p>
+                                    <a href="{{route('admin.servers.sync')}}" class="btn btn-primary btn-md"><i
+                                        class="fas fa-sync mr-2"></i>{{__('Sync servers')}}</a>
                                 </div>
                             @endif
                             <table class="table">

--- a/resources/views/admin/servers/index.blade.php
+++ b/resources/views/admin/servers/index.blade.php
@@ -25,7 +25,13 @@
 
             <div class="card">
                 <div class="card-header">
-                    <h5 class="card-title"><i class="fas fa-server mr-2"></i>{{__('Servers')}}</h5>
+                    <div class="d-flex justify-content-between">
+                        <div class="card-title ">
+                            <span><i class="fas fa-server mr-2"></i>{{__('Servers')}}</span>
+                        </div>
+                        <a href="{{route('admin.servers.sync')}}" class="btn btn-primary btn-sm"><i
+                                class="fas fa-sync mr-2"></i>{{__('Sync')}}</a>
+                    </div>
                 </div>
                 <div class="card-body table-responsive">
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -128,6 +128,7 @@ Route::middleware(['auth', 'checkSuspended'])->group(function () {
         #servers
         Route::get('servers/datatable', [AdminServerController::class, 'datatable'])->name('servers.datatable');
         Route::post('servers/togglesuspend/{server}', [AdminServerController::class, 'toggleSuspended'])->name('servers.togglesuspend');
+        Route::get('servers/sync', [AdminServerController::class, 'syncServers'])->name('servers.sync');
         Route::resource('servers', AdminServerController::class);
 
         #products


### PR DESCRIPTION
Stopped caching of the Admin overview page.

Added a sync server button, that deletes servers, that don't exist anymore on ptero, from CP. It is available at **/admin/servers** and in the perpage limit error message. The button also syncs server names.

![image](https://user-images.githubusercontent.com/89067167/197274550-28c02df1-f880-4faf-b510-fc88868a9301.png)
![image](https://user-images.githubusercontent.com/89067167/197274687-8fd9ba42-8154-4997-8059-38baa834dd5a.png)
