### PR TITLE
Fix: environment file crashes installer on new installations

### DIFF
--- a/public/install/functions.php
+++ b/public/install/functions.php
@@ -9,6 +9,10 @@ use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 
+if (!file_exists('../../.env')) {
+        echo run_console('cp .env.example .env');
+}
+
 (new DotEnv(dirname(__FILE__, 3) . '/.env'))->load();
 
 $required_extensions = ['openssl', 'gd', 'mysql', 'PDO', 'mbstring', 'tokenizer', 'bcmath', 'xml', 'curl', 'zip', 'intl'];

--- a/public/install/index.php
+++ b/public/install/index.php
@@ -53,9 +53,6 @@ $cardheader = '
         <div class="card-body bg-light">';
 
 if (!isset($_GET['step'])) {
-    if (!file_exists('../../.env')) {
-        echo run_console('cp .env.example .env');
-    }
     echo $cardheader; ?>
     <p class="login-box-msg">This installer will lead you through the most crucial Steps of Controlpanel.gg`s
         setup</p>


### PR DESCRIPTION
This PR simply moves a few lines to the proper file to avoid the crash on new installations. See the commits for more details